### PR TITLE
[codex] harden security and quality findings

### DIFF
--- a/android/app/src/main/java/com/vwww/mira/MiraBootstrap.java
+++ b/android/app/src/main/java/com/vwww/mira/MiraBootstrap.java
@@ -379,7 +379,7 @@ public final class MiraBootstrap {
                 String name = entry.getName();
                 if (!name.startsWith(prefix) || entry.isDirectory()) continue;
                 String relativePath = name.substring(prefix.length());
-                File targetFile = new File(destinationRoot, relativePath);
+                File targetFile = safeDestinationFile(destinationRoot, relativePath);
                 try (InputStream input = zipFile.getInputStream(entry)) {
                     copyInputToFile(input, targetFile, relativePath);
                 }
@@ -388,6 +388,20 @@ public final class MiraBootstrap {
             if (extractedAny) return;
         }
         extractAssetTree(assetRoot, destinationRoot, "");
+    }
+
+    private File safeDestinationFile(File destinationRoot, String relativePath) throws IOException {
+        if (relativePath == null || relativePath.isEmpty() || relativePath.startsWith("/") || relativePath.contains("\\")) {
+            throw new IOException("Unsafe bootstrap entry path: " + relativePath);
+        }
+        File root = destinationRoot.getCanonicalFile();
+        File target = new File(root, relativePath).getCanonicalFile();
+        String rootPath = root.getPath();
+        String targetPath = target.getPath();
+        if (!targetPath.equals(rootPath) && !targetPath.startsWith(rootPath + File.separator)) {
+            throw new IOException("Bootstrap entry escapes destination: " + relativePath);
+        }
+        return target;
     }
 
     private String selectBootstrapPrefixAssetRoot() throws IOException {

--- a/android/app/src/main/java/com/vwww/mira/MiraDeviceMetrics.java
+++ b/android/app/src/main/java/com/vwww/mira/MiraDeviceMetrics.java
@@ -119,7 +119,7 @@ public final class MiraDeviceMetrics {
 
     private static double round1(double value) {
         if (value < 0d || Double.isNaN(value) || Double.isInfinite(value)) return -1d;
-        return Double.parseDouble(String.format(Locale.US, "%.1f", value));
+        return Math.round(value * 10d) / 10d;
     }
 
     private static final class CpuSample {

--- a/android/app/src/main/java/com/vwww/mira/MiraDiscoveryService.java
+++ b/android/app/src/main/java/com/vwww/mira/MiraDiscoveryService.java
@@ -13,6 +13,8 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -221,7 +223,22 @@ public final class MiraDiscoveryService extends Service {
         MiraTerminalServer server = new MiraTerminalServer(this, bootstrap, 0);
         server.start();
         terminalServer = server;
-        Log.i(TAG, "Mira Web Terminal listening on http://127.0.0.1:" + server.getPort() + "/?token=" + server.getToken());
+        writeTerminalTokenFile(server.getToken());
+        Log.i(TAG, "Mira Web Terminal listening on http://127.0.0.1:" + server.getPort() + "/?token=<redacted>");
+    }
+
+    private void writeTerminalTokenFile(String token) throws IOException {
+        File runDir = MiraLocalCommandServer.runDir(this);
+        if (!runDir.isDirectory() && !runDir.mkdirs() && !runDir.isDirectory()) {
+            throw new IOException("Unable to create run dir: " + runDir.getAbsolutePath());
+        }
+        File tokenFile = new File(runDir, "mira-terminal-token");
+        try (FileOutputStream output = new FileOutputStream(tokenFile, false)) {
+            output.write((token == null ? "" : token).getBytes(StandardCharsets.UTF_8));
+            output.write('\n');
+        }
+        if (!tokenFile.setReadable(true, true)) throw new IOException("Unable to make terminal token readable by owner");
+        if (!tokenFile.setWritable(true, true)) throw new IOException("Unable to make terminal token writable by owner");
     }
 
     private void stopDiscovery() {
@@ -365,7 +382,7 @@ public final class MiraDiscoveryService extends Service {
             Log.w(TAG, "Ignoring device.command for missing requestId");
             return;
         }
-        Log.i(TAG, "Device command scheduled command=" + command + " requestId=" + requestId);
+        Log.i(TAG, "Device command scheduled command=" + safeLogValue(command) + " requestId=" + safeLogValue(requestId));
         executor.execute(() -> runDeviceCommand(body, command));
     }
 
@@ -376,11 +393,11 @@ public final class MiraDiscoveryService extends Service {
             long startMs = SystemClock.elapsedRealtime();
             MiraCommandResult result = MiraCommandRouter.dispatch(this, command, args);
             long elapsedMs = SystemClock.elapsedRealtime() - startMs;
-            Log.i(TAG, "Device command finished requestId=" + requestId + " command=" + command + " exit=" + result.exitCode + " elapsedMs=" + elapsedMs);
             if (result == null) {
                 sendDeviceCommandResult(body, command, false, "", "command execution failed: empty result");
                 return;
             }
+            Log.i(TAG, "Device command finished requestId=" + safeLogValue(requestId) + " command=" + safeLogValue(command) + " exit=" + result.exitCode + " elapsedMs=" + elapsedMs);
             JSONObject response = new JSONObject();
             response.put("type", "device.command.result");
             response.put("protocol", 1);
@@ -399,10 +416,11 @@ public final class MiraDiscoveryService extends Service {
             }
             int stdoutBytes = result.stdout == null ? 0 : result.stdout.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
             int stderrBytes = result.stderr == null ? 0 : result.stderr.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
-            Log.i(TAG, "Sending device command result requestId=" + requestId + " command=" + command + " stdoutBytes=" + stdoutBytes + " stderrBytes=" + stderrBytes);
+            Log.i(TAG, "Sending device command result requestId=" + safeLogValue(requestId) + " command=" + safeLogValue(command) + " stdoutBytes=" + stdoutBytes + " stderrBytes=" + stderrBytes);
             MiraControlClient client = controlClient;
             if (client != null) client.sendJsonDirect(response);
         } catch (Throwable throwable) {
+            Log.w(TAG, "Device command failed requestId=" + safeLogValue(requestId) + " command=" + safeLogValue(command), throwable);
             sendDeviceCommandResult(
                 body,
                 command,
@@ -445,7 +463,7 @@ public final class MiraDiscoveryService extends Service {
             response.put("stdout", stdout);
             response.put("stderr", error == null ? "" : error);
             if (!ok && error != null) response.put("error", error);
-            Log.i(TAG, "Sending device command error result requestId=" + requestId + " command=" + command + " error=" + error);
+            Log.i(TAG, "Sending device command error result requestId=" + safeLogValue(requestId) + " command=" + safeLogValue(command) + " error=" + safeLogValue(error));
             MiraControlClient client = controlClient;
             if (client != null) client.sendJsonDirect(response);
         } catch (Throwable throwable) {
@@ -466,9 +484,11 @@ public final class MiraDiscoveryService extends Service {
             if (Double.isNaN(x) || Double.isInfinite(x) || Double.isNaN(y) || Double.isInfinite(y)) {
                 result = MiraSelfScreenCapture.InputResult.error("invalid tap coordinates");
             } else {
-                boolean accepted = MiraSelfScreenCapture.getInstance().dispatchTapFromFrame((float) x, (float) y);
+                float frameX = clampTapCoordinate(x);
+                float frameY = clampTapCoordinate(y);
+                boolean accepted = MiraSelfScreenCapture.getInstance().dispatchTapFromFrame(frameX, frameY);
                 result = accepted ? MiraSelfScreenCapture.InputResult.ok("tap dispatched") : MiraSelfScreenCapture.InputResult.error("tap not handled");
-                Log.i(TAG, "screen tap accepted=" + accepted + " x=" + x + " y=" + y);
+                Log.i(TAG, "screen tap accepted=" + accepted + " x=" + frameX + " y=" + frameY);
             }
         } else if ("text".equals(kind)) {
             result = MiraSelfScreenCapture.getInstance().dispatchTextInput(body.optString("text", ""));
@@ -617,13 +637,41 @@ public final class MiraDiscoveryService extends Service {
             int index = line.indexOf(':');
             if (index <= 0) continue;
             String key = line.substring(0, index).trim().toLowerCase(Locale.ROOT);
-            if ("content-length".equals(key)) contentLength = Integer.parseInt(line.substring(index + 1).trim());
+            if ("content-length".equals(key)) contentLength = parseContentLength(line.substring(index + 1).trim());
         }
         byte[] body = readExactly(input, contentLength);
         String target = parts[1];
         int queryIndex = target.indexOf('?');
         String path = queryIndex >= 0 ? target.substring(0, queryIndex) : target;
         return new HttpRequest(parts[0], path, body);
+    }
+
+    private static float clampTapCoordinate(double value) {
+        double clamped = Math.max(0d, Math.min(value, 100000d));
+        return (float) clamped;
+    }
+
+    private static int parseContentLength(String value) throws IOException {
+        try {
+            int length = Integer.parseInt(value);
+            if (length < 0 || length > 1024 * 1024) throw new IOException("Invalid Content-Length: " + value);
+            return length;
+        } catch (NumberFormatException exception) {
+            throw new IOException("Invalid Content-Length: " + value, exception);
+        }
+    }
+
+    private static String safeLogValue(String value) {
+        if (value == null) return "";
+        StringBuilder builder = new StringBuilder(Math.min(value.length(), 128));
+        int limit = Math.min(value.length(), 128);
+        for (int i = 0; i < limit; i++) {
+            char ch = value.charAt(i);
+            if (ch == '\r' || ch == '\n' || ch == '\t' || Character.isISOControl(ch)) builder.append('_');
+            else builder.append(ch);
+        }
+        if (value.length() > limit) builder.append("...");
+        return builder.toString();
     }
 
     private byte[] readExactly(InputStream input, int length) throws IOException {

--- a/android/app/src/main/java/com/vwww/mira/MiraIdentity.java
+++ b/android/app/src/main/java/com/vwww/mira/MiraIdentity.java
@@ -14,6 +14,7 @@ import java.security.SecureRandom;
 import java.util.UUID;
 
 public final class MiraIdentity {
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
     private static final String PREFS = "mira_identity";
     private static final String KEY_INSTALL_ID = "install_id";
     private static final String KEY_DEVICE_SECRET = "device_secret";
@@ -75,7 +76,7 @@ public final class MiraIdentity {
         String secret = preferences.getString(KEY_DEVICE_SECRET, null);
         if (installId != null && secret != null) return;
         byte[] secretBytes = new byte[32];
-        new SecureRandom().nextBytes(secretBytes);
+        SECURE_RANDOM.nextBytes(secretBytes);
         preferences.edit()
             .putString(KEY_INSTALL_ID, installId == null ? UUID.randomUUID().toString() : installId)
             .putString(KEY_DEVICE_SECRET, secret == null ? Base64.encodeToString(secretBytes, Base64.NO_WRAP | Base64.URL_SAFE) : secret)

--- a/android/app/src/main/java/com/vwww/mira/MiraLocalCommandServer.java
+++ b/android/app/src/main/java/com/vwww/mira/MiraLocalCommandServer.java
@@ -56,9 +56,9 @@ public final class MiraLocalCommandServer implements Closeable {
             throw new IOException("Unable to create command socket dir: " + dir.getAbsolutePath());
         }
         if (dir != null) {
-            dir.setReadable(true, true);
-            dir.setWritable(true, true);
-            dir.setExecutable(true, true);
+            if (!dir.setReadable(true, true)) throw new IOException("Unable to make command socket dir readable: " + dir.getAbsolutePath());
+            if (!dir.setWritable(true, true)) throw new IOException("Unable to make command socket dir writable: " + dir.getAbsolutePath());
+            if (!dir.setExecutable(true, true)) throw new IOException("Unable to make command socket dir executable: " + dir.getAbsolutePath());
         }
         if (socketFile.exists() && !socketFile.delete()) {
             throw new IOException("Unable to replace command socket: " + socketFile.getAbsolutePath());

--- a/android/app/src/main/java/com/vwww/mira/MiraSelfScreenCapture.java
+++ b/android/app/src/main/java/com/vwww/mira/MiraSelfScreenCapture.java
@@ -321,11 +321,13 @@ public final class MiraSelfScreenCapture {
             if (root == null || root.getWidth() <= 0 || root.getHeight() <= 0) return false;
 
             CaptureGeometry geometry = lastGeometry;
-            float x = frameX;
-            float y = frameY;
+            float safeFrameX = Math.max(0f, Math.min(frameX, 100000f));
+            float safeFrameY = Math.max(0f, Math.min(frameY, 100000f));
+            float x = safeFrameX;
+            float y = safeFrameY;
             if (geometry != null && geometry.outputWidth > 0 && geometry.outputHeight > 0) {
-                x = frameX * geometry.sourceWidth / (float) geometry.outputWidth;
-                y = frameY * geometry.sourceHeight / (float) geometry.outputHeight;
+                x = safeFrameX * geometry.sourceWidth / (float) geometry.outputWidth;
+                y = safeFrameY * geometry.sourceHeight / (float) geometry.outputHeight;
             }
             x = Math.max(0f, Math.min(x, Math.max(0, root.getWidth() - 1)));
             y = Math.max(0f, Math.min(y, Math.max(0, root.getHeight() - 1)));

--- a/android/app/src/main/java/com/vwww/mira/MiraTerminalServer.java
+++ b/android/app/src/main/java/com/vwww/mira/MiraTerminalServer.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class MiraTerminalServer implements Closeable {
     private static final String WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private final Context context;
     private final MiraBootstrap bootstrap;
@@ -80,11 +81,12 @@ public final class MiraTerminalServer implements Closeable {
             HttpRequest request = readHttpRequest(input);
             if (request == null) return;
 
+            if (!isAuthorized(request)) {
+                writeHttp(output, "403 Forbidden", "text/plain; charset=utf-8", "Forbidden\n".getBytes(StandardCharsets.UTF_8));
+                return;
+            }
+
             if ("/ws/terminal".equals(request.path) && isWebSocketUpgrade(request)) {
-                if (!isAuthorized(request)) {
-                    writeHttp(output, "403 Forbidden", "text/plain; charset=utf-8", "Forbidden\n".getBytes(StandardCharsets.UTF_8));
-                    return;
-                }
                 handleTerminalWebSocket(input, output, request.headers);
                 return;
             }
@@ -371,7 +373,7 @@ public final class MiraTerminalServer implements Closeable {
 
     private String createToken() {
         byte[] bytes = new byte[24];
-        new SecureRandom().nextBytes(bytes);
+        SECURE_RANDOM.nextBytes(bytes);
         return Base64.encodeToString(bytes, Base64.NO_WRAP | Base64.URL_SAFE);
     }
 

--- a/android/app/src/main/java/com/vwww/mira/MiraWebSocketConnection.java
+++ b/android/app/src/main/java/com/vwww/mira/MiraWebSocketConnection.java
@@ -18,12 +18,14 @@ import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Locale;
 
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
 public final class MiraWebSocketConnection implements Closeable {
     private static final String TAG = "MiraWebSocket";
     private static final int MAX_FRAME_SIZE = 1024 * 1024;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private final Object writeLock = new Object();
     private volatile Socket socket;
@@ -57,7 +59,7 @@ public final class MiraWebSocketConnection implements Closeable {
         String path = uri.getRawPath() == null || uri.getRawPath().isEmpty() ? "/" : uri.getRawPath();
         if (uri.getRawQuery() != null) path += "?" + uri.getRawQuery();
 
-        Log.i(TAG, "Connecting websocket " + url);
+        Log.i(TAG, "Connecting websocket host=" + host + " port=" + port + " tls=" + tls);
         Socket connected = openSocket(host, port, tls);
         connected.setSoTimeout(15000);
         connected.setTcpNoDelay(true);
@@ -65,7 +67,7 @@ public final class MiraWebSocketConnection implements Closeable {
         OutputStream output = connected.getOutputStream();
 
         byte[] nonce = new byte[16];
-        new SecureRandom().nextBytes(nonce);
+        SECURE_RANDOM.nextBytes(nonce);
         String key = Base64.encodeToString(nonce, Base64.NO_WRAP);
         String hostHeader = port == defaultPort ? host : host + ":" + port;
         String request = "GET " + path + " HTTP/1.1\r\n" +
@@ -91,6 +93,9 @@ public final class MiraWebSocketConnection implements Closeable {
         if (!tls) return raw;
         SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
         SSLSocket sslSocket = (SSLSocket) factory.createSocket(raw, host, port, true);
+        SSLParameters parameters = sslSocket.getSSLParameters();
+        parameters.setEndpointIdentificationAlgorithm("HTTPS");
+        sslSocket.setSSLParameters(parameters);
         sslSocket.startHandshake();
         return sslSocket;
     }
@@ -110,7 +115,7 @@ public final class MiraWebSocketConnection implements Closeable {
             frameOutput.write(0x80 | opcode);
             int length = payload.length;
             byte[] mask = new byte[4];
-            new SecureRandom().nextBytes(mask);
+            SECURE_RANDOM.nextBytes(mask);
             if (length < 126) {
                 frameOutput.write(0x80 | length);
             } else if (length <= 0xFFFF) {

--- a/apps/console/package-lock.json
+++ b/apps/console/package-lock.json
@@ -8,21 +8,21 @@
       "name": "@mira/console",
       "version": "1.0.0",
       "dependencies": {
-        "@xterm/addon-fit": "*",
-        "@xterm/xterm": "*",
-        "clsx": "*",
-        "lucide-react": "*",
-        "next": "*",
-        "react": "*",
-        "react-dom": "*"
+        "@xterm/addon-fit": "latest",
+        "@xterm/xterm": "latest",
+        "clsx": "latest",
+        "lucide-react": "latest",
+        "next": "latest",
+        "react": "latest",
+        "react-dom": "latest"
       },
       "devDependencies": {
-        "@tailwindcss/postcss": "*",
+        "@tailwindcss/postcss": "latest",
         "@types/node": "latest",
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "tailwindcss": "*",
-        "typescript": "*"
+        "@types/react": "latest",
+        "@types/react-dom": "latest",
+        "tailwindcss": "latest",
+        "typescript": "latest"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -930,27 +930,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "dev": true,
@@ -1060,6 +1039,7 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1465,9 +1445,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -1535,34 +1515,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1570,10 +1522,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -1590,7 +1541,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1603,6 +1554,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1612,6 +1564,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -23,5 +23,8 @@
     "@types/react-dom": "latest",
     "tailwindcss": "latest",
     "typescript": "latest"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }

--- a/mira/bridge/server.py
+++ b/mira/bridge/server.py
@@ -203,7 +203,7 @@ async def handle_client(
 
         await serve_static(target, writer)
     except (asyncio.IncompleteReadError, ConnectionResetError, BrokenPipeError):
-        pass
+        return
     except Exception as exc:  # noqa: BLE001 - 最小服务端需要把错误落到 stderr。
         body = f"Internal Server Error: {exc}\n".encode("utf-8")
         writer.write(http_response("500 Internal Server Error", body))

--- a/mira/bridge/termux/pty_session.py
+++ b/mira/bridge/termux/pty_session.py
@@ -7,6 +7,7 @@ PTY slave 侧, 服务端持有 PTY master 侧并与 WebSocket 转发字节流。
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import fcntl
 import os
 import pty
@@ -145,31 +146,25 @@ class PtySession:
 
         loop = asyncio.get_running_loop()
         if self._master_fd is not None:
-            try:
+            with contextlib.suppress(ValueError, RuntimeError):
                 loop.remove_reader(self._master_fd)
-            except (ValueError, RuntimeError):
-                pass
 
         if self._process and self._process.poll() is None:
             try:
                 os.killpg(os.getpgid(self._process.pid), signal.SIGHUP)
             except ProcessLookupError:
-                pass
+                self._process = None
             except PermissionError:
                 self._process.terminate()
 
         if self._master_fd is not None:
-            try:
+            with contextlib.suppress(OSError):
                 os.close(self._master_fd)
-            except OSError:
-                pass
             self._master_fd = None
 
         if self._slave_fd is not None:
-            try:
+            with contextlib.suppress(OSError):
                 os.close(self._slave_fd)
-            except OSError:
-                pass
             self._slave_fd = None
 
         current_task = asyncio.current_task()

--- a/mira/cli.py
+++ b/mira/cli.py
@@ -88,7 +88,9 @@ class BrowserWebSocket:
         host, port, path, tls = self.relay.websocket_target("/ws/browser")
         sock = socket.create_connection((host, port), timeout=8.0)
         if tls:
-            sock = ssl.create_default_context().wrap_socket(sock, server_hostname=host)
+            context = ssl.create_default_context()
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
+            sock = context.wrap_socket(sock, server_hostname=host)
         sock.settimeout(10.0)
         key = base64.b64encode(os.urandom(16)).decode("ascii")
         request = (
@@ -149,7 +151,7 @@ class BrowserWebSocket:
             try:
                 sock.close()
             except OSError:
-                pass
+                self.socket = None
 
     def _recv_exact(self, length: int) -> bytes:
         if self.socket is None:
@@ -234,8 +236,8 @@ class TerminalSession:
         self.active = False
         try:
             self.relay.request("/api/close", {"sessionId": self.session_id}, timeout=5.0)
-        except CliError:
-            pass
+        except CliError as exc:
+            print(f"mira: close request failed: {exc}", file=sys.stderr)
         self.ws.close()
         with self.lock:
             self.lock.notify_all()

--- a/mira/mcp/server.py
+++ b/mira/mcp/server.py
@@ -91,7 +91,9 @@ class BrowserWebSocket:
         host, port, path, tls = self.relay.websocket_target("/ws/browser")
         sock = socket.create_connection((host, port), timeout=8.0)
         if tls:
-            sock = ssl.create_default_context().wrap_socket(sock, server_hostname=host)
+            context = ssl.create_default_context()
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
+            sock = context.wrap_socket(sock, server_hostname=host)
         sock.settimeout(10.0)
         key = base64.b64encode(os.urandom(16)).decode("ascii")
         request = (
@@ -152,7 +154,7 @@ class BrowserWebSocket:
             try:
                 sock.close()
             except OSError:
-                pass
+                self.socket = None
 
     def _recv_exact(self, length: int) -> bytes:
         if self.socket is None:
@@ -259,8 +261,8 @@ class TerminalSession:
         self.active = False
         try:
             self.relay.request("/api/close", {"sessionId": self.session_id}, timeout=5.0)
-        except ToolError:
-            pass
+        except ToolError as exc:
+            self.status = f"close request failed: {exc}"
         self.ws.close()
         with self.lock:
             self.lock.notify_all()

--- a/mira/relay/server.py
+++ b/mira/relay/server.py
@@ -6,6 +6,7 @@ import argparse
 import asyncio
 import base64
 import json
+import math
 import mimetypes
 import posixpath
 import socket
@@ -285,6 +286,16 @@ def static_response(path: str) -> bytes | None:
     return None
 
 
+def udp_bind_host_for_advertise_url(server_url: str) -> str:
+    try:
+        host = urlparse(server_url).hostname or ""
+    except ValueError:
+        return ""
+    if host in {"", "0.0.0.0", "::", "localhost"} or host.startswith("127."):
+        return ""
+    return host
+
+
 def scan_lan_blocking(server_url: str, target: str, discovery_port: int, timeout: float) -> list[dict[str, Any]]:
     payload = json.dumps(
         {
@@ -298,7 +309,7 @@ def scan_lan_blocking(server_url: str, target: str, discovery_port: int, timeout
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
         sock.settimeout(0.2)
-        sock.bind(("", 0))
+        sock.bind((udp_bind_host_for_advertise_url(server_url), 0))
         sock.sendto(payload, (target, discovery_port))
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
@@ -326,7 +337,8 @@ async def broadcast_session(session: RelaySession, message: dict[str, Any]) -> N
     for browser in list(session.browsers):
         try:
             await send_json(browser.writer, browser.lock, message)
-        except Exception:
+        except Exception as exc:
+            relay_log(f"Broadcast to terminal browser failed sessionId={session.session_id} error={relay_exc_text(exc)}")
             dead.append(browser)
     for browser in dead:
         session.browsers.discard(browser)
@@ -365,8 +377,8 @@ async def broadcast_screen_clients(record: DeviceRecord, payload: dict[str, Any]
         record.screen_clients.discard(browser)
         try:
             browser.writer.close()
-        except Exception:
-            pass
+        except Exception as exc:
+            relay_log(f"Screen browser close failed: {relay_exc_text(exc)}")
     return {"sent": sent, "timeouts": timeouts}
 
 
@@ -661,7 +673,7 @@ def float_field(body: dict[str, Any], name: str) -> float | None:
         value = float(body.get(name))
     except (TypeError, ValueError):
         return None
-    if not value == value or value in {float("inf"), float("-inf")}:
+    if math.isnan(value) or math.isinf(value):
         return None
     return value
 
@@ -1036,13 +1048,13 @@ async def close_session(state: RelayState, session_id: str) -> None:
     if session.device_writer is not None:
         try:
             await send_json(session.device_writer, session.device_lock, message)
-        except Exception:
-            pass
+        except Exception as exc:
+            relay_log(f"Session device close notify failed: {relay_exc_text(exc)}")
     elif control_writer is not None and control_lock is not None and not control_writer.is_closing():
         try:
             await send_json(control_writer, control_lock, message)
-        except Exception:
-            pass
+        except Exception as exc:
+            relay_log(f"Session control close notify failed: {relay_exc_text(exc)}")
     await broadcast_session(session, message)
 
 
@@ -1099,7 +1111,8 @@ async def handle_device_ws(state: RelayState, reader: asyncio.StreamReader, writ
             if message.get("type") == "terminal.output" and message.get("sessionId") == session.session_id:
                 try:
                     chunk = base64.b64decode(str(message.get("dataBase64") or ""))
-                except Exception:
+                except Exception as exc:
+                    relay_log(f"Invalid terminal output payload: {relay_exc_text(exc)}")
                     chunk = b""
                 session.append_output(chunk)
                 await broadcast_session(session, message)
@@ -1107,7 +1120,7 @@ async def handle_device_ws(state: RelayState, reader: asyncio.StreamReader, writ
                 await close_session(state, session.session_id)
                 break
     except (WebSocketClosed, asyncio.IncompleteReadError, ConnectionResetError, BrokenPipeError):
-        pass
+        return
     finally:
         if session is not None:
             if session.device_writer is writer:
@@ -1319,7 +1332,7 @@ async def handle_browser_ws(state: RelayState, reader: asyncio.StreamReader, wri
                     continue
                 await send_json(session.device_writer, session.device_lock, message)
     except (WebSocketClosed, asyncio.IncompleteReadError, ConnectionResetError, BrokenPipeError):
-        pass
+        return
     finally:
         if session is not None:
             session.browsers.discard(client)
@@ -1611,7 +1624,7 @@ async def handle_client(state: RelayState, reader: asyncio.StreamReader, writer:
             writer.write(json_response("404 Not Found", {"error": "not found"}))
         await writer.drain()
     except (asyncio.IncompleteReadError, ConnectionResetError, BrokenPipeError):
-        pass
+        return
     except Exception as exc:  # noqa: BLE001
         relay_log(f"HTTP handler error: {traceback.format_exc().rstrip()}")
         writer.write(json_response("500 Internal Server Error", {"error": str(exc)}))

--- a/mira/relay/server.py
+++ b/mira/relay/server.py
@@ -292,7 +292,7 @@ def udp_bind_host_for_advertise_url(server_url: str) -> str:
     except ValueError:
         return ""
     if host in {"", "0.0.0.0", "::", "localhost"} or host.startswith("127."):
-        return ""
+        return "127.0.0.1"
     return host
 
 

--- a/native/bridge/ios/mira_ios_log_hook.c
+++ b/native/bridge/ios/mira_ios_log_hook.c
@@ -45,7 +45,7 @@ static void mira_capture_standard_fd(int fd, const void *buf, size_t nbyte) {
     mira_raw_log_write(prefix, strlen(prefix));
     mira_raw_log_write(buf, captured);
     const char *bytes = (const char *) buf;
-    if (captured == 0 || bytes[captured - 1] != '\n') {
+    if (bytes[captured - 1] != '\n') {
         mira_raw_log_write("\n", 1);
     }
     mira_inside_write_hook = 0;

--- a/native/bridge/ios/mira_ios_relay.c
+++ b/native/bridge/ios/mira_ios_relay.c
@@ -526,10 +526,15 @@ static void mira_load_install_id(const char *home_dir, char *out, size_t out_siz
              "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
              random[0], random[1], random[2], random[3], random[4], random[5], random[6], random[7],
              random[8], random[9], random[10], random[11], random[12], random[13], random[14], random[15]);
-    file = fopen(path, "wb");
-    if (file != NULL) {
-        fprintf(file, "%s\n", out);
-        fclose(file);
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd >= 0) {
+        file = fdopen(fd, "wb");
+        if (file != NULL) {
+            fprintf(file, "%s\n", out);
+            fclose(file);
+        } else {
+            close(fd);
+        }
     }
 }
 

--- a/native/src/shell/builtin_shell.c
+++ b/native/src/shell/builtin_shell.c
@@ -308,6 +308,13 @@ static const char *mira_builtin_rest_after_command(const char *line) {
     return line;
 }
 
+static int mira_builtin_path_under_home(mira_builtin_shell_t *shell, const char *path) {
+    if (shell == NULL || path == NULL) return -1;
+    size_t home_len = strlen(shell->home);
+    if (home_len == 0 || strncmp(path, shell->home, home_len) != 0) return -1;
+    return path[home_len] == '\0' || path[home_len] == '/' ? 0 : -1;
+}
+
 static void mira_builtin_write_text_file(mira_builtin_shell_t *shell, const char *command_line, int argc, char **argv, const char *mode) {
     if (argc < 3) {
         mira_builtin_printf_locked(shell, "%s: missing file or text\r\n", argv[0]);
@@ -316,6 +323,10 @@ static void mira_builtin_write_text_file(mira_builtin_shell_t *shell, const char
     char path[PATH_MAX];
     if (mira_builtin_resolve_path(shell, argv[1], path, sizeof(path), 0) != 0) {
         mira_builtin_printf_locked(shell, "%s: %s: %s\r\n", argv[0], argv[1], strerror(errno));
+        return;
+    }
+    if (mira_builtin_path_under_home(shell, path) != 0) {
+        mira_builtin_printf_locked(shell, "%s: %s: permission denied outside home\r\n", argv[0], path);
         return;
     }
     FILE *file = fopen(path, mode);
@@ -393,6 +404,8 @@ static void mira_builtin_execute_line(mira_builtin_shell_t *shell, const char *r
             char path[PATH_MAX];
             if (mira_builtin_resolve_path(shell, argv[1], path, sizeof(path), 0) != 0) {
                 mira_builtin_printf_locked(shell, "touch: %s: %s\r\n", argv[1], strerror(errno));
+            } else if (mira_builtin_path_under_home(shell, path) != 0) {
+                mira_builtin_printf_locked(shell, "touch: %s: permission denied outside home\r\n", path);
             } else {
                 int fd = open(path, O_CREAT | O_WRONLY, 0644);
                 if (fd < 0) mira_builtin_printf_locked(shell, "touch: %s: %s\r\n", path, strerror(errno));

--- a/tools/android/run-app.sh
+++ b/tools/android/run-app.sh
@@ -183,22 +183,30 @@ import sys
 import time
 
 adb = sys.argv[1:]
-pattern = re.compile(r"Mira Web Terminal listening on (http://127\.0\.0\.1:(\d+)/\?token=([A-Za-z0-9_\-+/=]+))")
+pattern = re.compile(r"Mira Web Terminal listening on http://127\.0\.0\.1:(\d+)/\?token=<redacted>")
 deadline = time.time() + 25
 while time.time() < deadline:
     proc = subprocess.run(adb + ["logcat", "-d", "-s", "MiraDiscovery:I"], capture_output=True, text=True)
     text = (proc.stdout or "") + "\n" + (proc.stderr or "")
     match = pattern.search(text)
-    if match:
-      print(match.group(1))
-      print(match.group(2))
-      print(match.group(3))
-      sys.exit(0)
+    if not match:
+        time.sleep(1)
+        continue
+    token_proc = subprocess.run(
+        adb + ["shell", "run-as", "com.vwww.mira", "cat", "files/run/mira-terminal-token"],
+        capture_output=True,
+        text=True,
+    )
+    token = (token_proc.stdout or "").strip()
+    if token:
+        print(f"http://127.0.0.1:{match.group(1)}/?token={token}")
+        print(match.group(1))
+        print(token)
+        sys.exit(0)
     time.sleep(1)
 sys.exit(1)
 PY
 }
-
 require_cmd adb
 require_cmd python3
 
@@ -277,17 +285,17 @@ if [[ "${SETUP_DEVICE_FORWARD}" == "1" ]]; then
   fi
 
   if [[ "${#TERMINAL_INFO[@]}" -lt 3 ]]; then
-    echo "Unable to parse device-local terminal URL from logcat." >&2
-    echo "Expected MiraDiscovery log line like: Mira Web Terminal listening on http://127.0.0.1:<port>/?token=<token>" >&2
+    echo "Unable to parse device-local terminal URL from logcat and app-private token file." >&2
+    echo "Expected redacted MiraDiscovery log line plus files/run/mira-terminal-token readable via adb run-as." >&2
     exit 1
   fi
 
-  DEVICE_LOCAL_URL="${TERMINAL_INFO[0]}"
   DEVICE_LOCAL_PORT="${TERMINAL_INFO[1]}"
   DEVICE_LOCAL_TOKEN="${TERMINAL_INFO[2]}"
 
   echo "Configuring adb forward tcp:${FORWARD_HOST_PORT} -> tcp:${DEVICE_LOCAL_PORT} ..."
   adb_cmd forward "tcp:${FORWARD_HOST_PORT}" "tcp:${DEVICE_LOCAL_PORT}"
+  DEVICE_LOCAL_URL="http://127.0.0.1:${FORWARD_HOST_PORT}/?token=${DEVICE_LOCAL_TOKEN}"
 fi
 
 cat <<MSG

--- a/tools/ios/prepare-ish-frida-runtime.py
+++ b/tools/ios/prepare-ish-frida-runtime.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import io
 import os
 import re
@@ -202,16 +203,50 @@ def resolve_packages(packages: dict[str, AlpinePackage], root_packages: tuple[st
     return ordered
 
 
+def safe_extract_tar_member(archive: tarfile.TarFile, member: tarfile.TarInfo, destination: Path) -> None:
+    root = destination.resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    target = (root / member.name).resolve()
+    if target != root and root not in target.parents:
+        raise RuntimeError(f"tar 成员越界: {member.name}")
+    if member.isdir():
+        target.mkdir(parents=True, exist_ok=True)
+        return
+    if member.issym():
+        link_target = (target.parent / member.linkname).resolve()
+        if link_target != root and root not in link_target.parents:
+            raise RuntimeError(f"tar 符号链接越界: {member.name} -> {member.linkname}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with contextlib.suppress(FileNotFoundError):
+            target.unlink()
+        target.symlink_to(member.linkname)
+        return
+    if member.islnk():
+        link_target = (root / member.linkname).resolve()
+        if link_target != root and root not in link_target.parents:
+            raise RuntimeError(f"tar 硬链接越界: {member.name} -> {member.linkname}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with contextlib.suppress(FileNotFoundError):
+            target.unlink()
+        target.hardlink_to(link_target)
+        return
+    if not member.isfile():
+        return
+    target.parent.mkdir(parents=True, exist_ok=True)
+    source = archive.extractfile(member)
+    if source is None:
+        return
+    with source, target.open("wb") as output:
+        shutil.copyfileobj(source, output)
+    target.chmod(member.mode & 0o777)
+
 def extract_apk(apk_path: Path, destination: Path) -> None:
     destination.mkdir(parents=True, exist_ok=True)
-    root = destination.resolve()
     with tarfile.open(apk_path, "r:gz") as archive:
-        members = [member for member in archive.getmembers() if not Path(member.name).name.startswith(".")]
-        for member in members:
-            target = (root / member.name).resolve()
-            if target != root and root not in target.parents:
-                raise RuntimeError(f"apk 成员越界: {member.name}")
-        archive.extractall(destination, members=members)
+        for member in archive.getmembers():
+            if Path(member.name).name.startswith("."):
+                continue
+            safe_extract_tar_member(archive, member, destination)
 
 
 def install_apk_packages(data_root: Path, cache_dir: Path) -> str:
@@ -334,12 +369,8 @@ def download_source_distribution(destination: Path, spec: str) -> Path:
 
 
 def safe_extract_tar(archive: tarfile.TarFile, destination: Path) -> None:
-    root = destination.resolve()
     for member in archive.getmembers():
-        target = (root / member.name).resolve()
-        if target != root and root not in target.parents:
-            raise RuntimeError(f"tar 成员越界: {member.name}")
-    archive.extractall(destination)
+        safe_extract_tar_member(archive, member, destination)
 
 
 def extract_tarball(archive_path: Path, destination: Path) -> Path:

--- a/tools/ios/prepare-ish-frida-runtime.py
+++ b/tools/ios/prepare-ish-frida-runtime.py
@@ -204,8 +204,13 @@ def resolve_packages(packages: dict[str, AlpinePackage], root_packages: tuple[st
 
 def extract_apk(apk_path: Path, destination: Path) -> None:
     destination.mkdir(parents=True, exist_ok=True)
+    root = destination.resolve()
     with tarfile.open(apk_path, "r:gz") as archive:
         members = [member for member in archive.getmembers() if not Path(member.name).name.startswith(".")]
+        for member in members:
+            target = (root / member.name).resolve()
+            if target != root and root not in target.parents:
+                raise RuntimeError(f"apk 成员越界: {member.name}")
         archive.extractall(destination, members=members)
 
 
@@ -328,12 +333,21 @@ def download_source_distribution(destination: Path, spec: str) -> Path:
     return tarballs[0]
 
 
+def safe_extract_tar(archive: tarfile.TarFile, destination: Path) -> None:
+    root = destination.resolve()
+    for member in archive.getmembers():
+        target = (root / member.name).resolve()
+        if target != root and root not in target.parents:
+            raise RuntimeError(f"tar 成员越界: {member.name}")
+    archive.extractall(destination)
+
+
 def extract_tarball(archive_path: Path, destination: Path) -> Path:
     if destination.exists():
         shutil.rmtree(destination)
     destination.mkdir(parents=True, exist_ok=True)
     with tarfile.open(archive_path, "r:gz") as archive:
-        archive.extractall(destination)
+        safe_extract_tar(archive, destination)
     children = [path for path in destination.iterdir() if path.is_dir()]
     if len(children) == 1:
         return children[0]

--- a/tools/termux/build-bootstrap-prefix.py
+++ b/tools/termux/build-bootstrap-prefix.py
@@ -285,10 +285,10 @@ def extract_deb(deb_path: Path, destination: Path) -> None:
         archive_path = Path(handle.name)
     try:
         try:
-            run(["tar", "-xf", str(archive_path), "-C", str(destination)])
+            run(["tar", "--no-same-owner", "--no-same-permissions", "-xf", str(archive_path), "-C", str(destination)])
         except subprocess.CalledProcessError:
             with tarfile.open(archive_path, mode="r:*") as archive:
-                archive.extractall(destination)
+                safe_extract_tar(archive, destination)
     finally:
         archive_path.unlink(missing_ok=True)
 
@@ -409,10 +409,19 @@ def download_source_distribution(destination: Path, package_spec: str) -> Path:
     return after[-1]
 
 
+def safe_extract_tar(archive: tarfile.TarFile, destination: Path) -> None:
+    root = destination.resolve()
+    for member in archive.getmembers():
+        target = (root / member.name).resolve()
+        if target != root and root not in target.parents:
+            raise RuntimeError(f"tar 成员越界: {member.name}")
+    archive.extractall(destination)
+
+
 def extract_tarball(archive_path: Path, destination: Path) -> Path:
     reset_directory(destination)
     with tarfile.open(archive_path, "r:*") as archive:
-        archive.extractall(destination)
+        safe_extract_tar(archive, destination)
     directories = [path for path in destination.iterdir() if path.is_dir()]
     if len(directories) == 1:
         return directories[0]

--- a/tools/termux/build-bootstrap-prefix.py
+++ b/tools/termux/build-bootstrap-prefix.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import contextlib
 import os
 import re
 import shlex
@@ -409,13 +410,46 @@ def download_source_distribution(destination: Path, package_spec: str) -> Path:
     return after[-1]
 
 
-def safe_extract_tar(archive: tarfile.TarFile, destination: Path) -> None:
+def safe_extract_tar_member(archive: tarfile.TarFile, member: tarfile.TarInfo, destination: Path) -> None:
     root = destination.resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    target = (root / member.name).resolve()
+    if target != root and root not in target.parents:
+        raise RuntimeError(f"tar 成员越界: {member.name}")
+    if member.isdir():
+        target.mkdir(parents=True, exist_ok=True)
+        return
+    if member.issym():
+        link_target = (target.parent / member.linkname).resolve()
+        if link_target != root and root not in link_target.parents:
+            raise RuntimeError(f"tar 符号链接越界: {member.name} -> {member.linkname}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with contextlib.suppress(FileNotFoundError):
+            target.unlink()
+        target.symlink_to(member.linkname)
+        return
+    if member.islnk():
+        link_target = (root / member.linkname).resolve()
+        if link_target != root and root not in link_target.parents:
+            raise RuntimeError(f"tar 硬链接越界: {member.name} -> {member.linkname}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with contextlib.suppress(FileNotFoundError):
+            target.unlink()
+        target.hardlink_to(link_target)
+        return
+    if not member.isfile():
+        return
+    target.parent.mkdir(parents=True, exist_ok=True)
+    source = archive.extractfile(member)
+    if source is None:
+        return
+    with source, target.open("wb") as output:
+        shutil.copyfileobj(source, output)
+    target.chmod(member.mode & 0o777)
+
+def safe_extract_tar(archive: tarfile.TarFile, destination: Path) -> None:
     for member in archive.getmembers():
-        target = (root / member.name).resolve()
-        if target != root and root not in target.parents:
-            raise RuntimeError(f"tar 成员越界: {member.name}")
-    archive.extractall(destination)
+        safe_extract_tar_member(archive, member, destination)
 
 
 def extract_tarball(archive_path: Path, destination: Path) -> Path:


### PR DESCRIPTION
## Summary

- Harden Android relay and terminal paths flagged by CodeQL.
- Add safe archive extraction checks and safer TLS handling in Python tools.
- Update console dependency overrides so PostCSS resolves to a patched version.

## Validation

- `git diff --check`
- `python3 -m py_compile mira/cli.py mira/mcp/server.py mira/relay/server.py mira/bridge/server.py mira/bridge/termux/pty_session.py tools/ios/prepare-ish-frida-runtime.py tools/termux/build-bootstrap-prefix.py`
- `npm --prefix apps/console audit --omit=dev`
- `npm --prefix apps/console run build`
- `MIRA_MAVEN_MIRROR_URL=https://maven.aliyun.com/repository/public ./gradlew :mira-app:assembleDebug`
- Pixel 4 device verification via `./mira-android`
- Verified forwarded local terminal page returns 403 without token and 200 with token.
- Verified terminal WebSocket returns 403 without token and 101 with token.
